### PR TITLE
better benchmark parameters

### DIFF
--- a/engine/skeleton/benchmark.cu
+++ b/engine/skeleton/benchmark.cu
@@ -4,7 +4,6 @@
 #include "tests.hpp"
 
 #include <algorithm>
-#include <chrono>
 #include <iomanip>
 #include <iostream>
 #include <utility>
@@ -12,21 +11,26 @@
 
 #include <cuda_runtime.h>
 
-static const size_t MINIMUM_RUNS = 2;
-static const double MINIMUM_TIME_SECS = 1.0;
+static const size_t MINIMUM_RUNS = 1;
+static const double MINIMUM_TIME_SECS = 0.5;
 
-inline float median(std::vector<float> &v) {
-    // return median of v
-    std::sort(v.begin(), v.end());
-    if (v.size() % 2 == 0) {
-        return (v[v.size() / 2 - 1] + v[v.size() / 2]) / 2;
-    } else {
-        return v[v.size() / 2];
+static const size_t MINIMUM_WARMUP_RUNS = 1;
+static const float MINIMUM_WARMUP_TIME_SECS = 0.5;
+
+size_t prefix_sum(const std::vector<float> &v, float target) {
+    // return first index where sum[0:i] >= target
+    size_t i = 0;
+    float sum = 0.0;
+
+    while (i < v.size() && sum < target) {
+        sum += v[i];
+        i++;
     }
+
+    return i;
 }
 
-template <typename T>
-class BenchmarkRunner {
+template <typename T> class BenchmarkRunner {
   private:
     cudaEvent_t start, stop;
     std::vector<T *> h_inputs;
@@ -86,18 +90,18 @@ class BenchmarkRunner {
     }
 
   public:
-    typedef void (*KernelLauncher)(const std::vector<T *> &, const std::vector<T *> &, const std::vector<size_t> &);
+    typedef void (*KernelLauncher)(const std::vector<T *> &, const std::vector<T *> &,
+                                   const std::vector<size_t> &);
 
     std::pair<size_t, float> run_benchmark(TestCase<T> &test_case) {
         size_t flops = test_case.calculate_flops();
         std::vector<size_t> sizes = test_case.get_sizes();
 
-        auto start_time = std::chrono::high_resolution_clock::now();
         double elapsed = 0.0;
-
         std::vector<float> runtimes;
 
-        while (elapsed < MINIMUM_TIME_SECS || runtimes.size() < MINIMUM_RUNS) {
+        while (elapsed < (MINIMUM_TIME_SECS + MINIMUM_WARMUP_TIME_SECS) ||
+               runtimes.size() < (MINIMUM_RUNS + MINIMUM_WARMUP_RUNS)) {
             cudaEventRecord(start);
             test_case.launch_kernel(d_inputs, d_outputs, sizes, reinterpret_cast<void *>(solution));
             cudaEventRecord(stop);
@@ -108,11 +112,19 @@ class BenchmarkRunner {
             cudaEventElapsedTime(&ms, start, stop);
             runtimes.push_back(ms);
 
-            elapsed = std::chrono::duration<double>(std::chrono::high_resolution_clock::now() - start_time).count();
+            elapsed += ms / 1000.0;
         }
 
-        const float min_time = *std::min_element(runtimes.begin(), runtimes.end());
-        return std::make_pair(flops, min_time);
+        size_t warmup_index = prefix_sum(runtimes, MINIMUM_WARMUP_TIME_SECS * 1000);
+        warmup_index = std::max(warmup_index, MINIMUM_WARMUP_RUNS);
+
+        // cut off warmup runs
+        runtimes.erase(runtimes.begin(), runtimes.begin() + warmup_index);
+
+        const float mean_time =
+            std::accumulate(runtimes.begin(), runtimes.end(), 0.0) / runtimes.size();
+
+        return std::make_pair(flops, mean_time);
     }
 };
 
@@ -132,7 +144,8 @@ void run_benchmarks(const std::vector<std::unique_ptr<TestCase<T>>> &test_cases)
         double gflops = (flops / 1e9) / (avg_ms / 1000.0);
         total_gflops += gflops;
 
-        std::cout << curr_testcase << "," << test_case->get_name() << "," << avg_ms << "," << gflops << std::endl;
+        std::cout << curr_testcase << "," << test_case->get_name() << "," << avg_ms << "," << gflops
+                  << std::endl;
         curr_testcase++;
     }
 

--- a/engine/skeleton/benchmark.cu
+++ b/engine/skeleton/benchmark.cu
@@ -11,8 +11,8 @@
 
 #include <cuda_runtime.h>
 
-static const size_t WARMUP_RUNS = 3;
-static const size_t MINIMUM_RUNS = 10;
+static const size_t WARMUP_RUNS = 10;
+static const size_t MINIMUM_RUNS = 20;
 static const double MINIMUM_TIME_SECS = 1.0;
 
 inline float median(std::vector<float> &v) {
@@ -102,7 +102,7 @@ class BenchmarkRunner {
             cudaDeviceSynchronize();
         }
 
-        while (elapsed < MINIMUM_TIME_SECS && runtimes.size() < MINIMUM_RUNS) {
+        while (elapsed < MINIMUM_TIME_SECS || runtimes.size() < MINIMUM_RUNS) {
             cudaEventRecord(start);
             test_case.launch_kernel(d_inputs, d_outputs, sizes, reinterpret_cast<void *>(solution));
             cudaEventRecord(stop);

--- a/src/pages/problems/[slug].tsx
+++ b/src/pages/problems/[slug].tsx
@@ -142,19 +142,21 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
 };
 
 const getStatusMessage = (status: SubmissionStatus): string => {
-  if (status.message?.startsWith("status: CHECKING") || status.status === "CHECKING") {
+  if (status.message?.startsWith("status: CHECKING")) {
     return "Checking...";
-  } else if (status.message?.startsWith("status: BENCHMARKING") || status.status === "BENCHMARKING") {
+  } else if (status.message?.startsWith("status: BENCHMARKING")) {
     return "Running benchmarks...";
   } else if (status.message?.startsWith("checker: compiling")) {
     return "Compiling...";
-  } else if (status.message?.startsWith("checker: running")) {
+  } else if (status.message?.startsWith("checker: running") || status.message?.startsWith("checker: test_result")) {
     return "Running tests...";
   } else if (status.message?.startsWith("checker: complete")) {
     return "Tests complete";
-  } else if (status.message?.startsWith("benchmark: compiling") || 
-             status.message?.startsWith("benchmark: running") ||
-             status.message?.startsWith("benchmark: test_result")) {
+  } else if (
+    status.message?.startsWith("benchmark: compiling") ||
+    status.message?.startsWith("benchmark: running") ||
+    status.message?.startsWith("benchmark: test_result")
+  ) {
     return "Running benchmarks...";
   } else if (status.message?.startsWith("benchmark: success")) {
     return "Benchmark results";
@@ -838,12 +840,24 @@ export default function ProblemPage({ slug }: { slug: string }) {
                       submissionStatus.status === "ACCEPTED" ||
                       submissionStatus.message?.startsWith("complete: ACCEPTED")
                         ? "green.900"
-                        : submissionStatus.message?.startsWith("status: CHECKING") ||
-                          submissionStatus.message?.startsWith("checker: compiling") ||
-                          submissionStatus.message?.startsWith("checker: running") ||
-                          submissionStatus.message?.startsWith("benchmark: compiling") ||
-                          submissionStatus.message?.startsWith("benchmark: running") ||
-                          submissionStatus.message?.startsWith("benchmark: test_result") ||
+                        : submissionStatus.message?.startsWith(
+                            "status: CHECKING"
+                          ) ||
+                          submissionStatus.message?.startsWith(
+                            "checker: compiling"
+                          ) ||
+                          submissionStatus.message?.startsWith(
+                            "checker: running"
+                          ) ||
+                          submissionStatus.message?.startsWith(
+                            "benchmark: compiling"
+                          ) ||
+                          submissionStatus.message?.startsWith(
+                            "benchmark: running"
+                          ) ||
+                          submissionStatus.message?.startsWith(
+                            "benchmark: test_result"
+                          ) ||
                           submissionStatus.status === "CHECKING" ||
                           submissionStatus.status === "BENCHMARKING"
                         ? "blue.900"
@@ -853,20 +867,34 @@ export default function ProblemPage({ slug }: { slug: string }) {
                     borderRadius="xl"
                   >
                     <HStack spacing={3}>
-                      {submissionStatus.message?.startsWith("status: CHECKING") ||
-                       submissionStatus.message?.startsWith("checker: compiling") ||
-                       submissionStatus.message?.startsWith("checker: running") ||
-                       submissionStatus.message?.startsWith("benchmark: compiling") ||
-                       submissionStatus.message?.startsWith("benchmark: running") ||
-                       submissionStatus.message?.startsWith("benchmark: test_result") ||
-                       submissionStatus.status === "CHECKING" ||
-                       submissionStatus.status === "BENCHMARKING" ? (
+                      {submissionStatus.message?.startsWith(
+                        "status: CHECKING"
+                      ) ||
+                      submissionStatus.message?.startsWith(
+                        "checker: compiling"
+                      ) ||
+                      submissionStatus.message?.startsWith(
+                        "checker: running"
+                      ) ||
+                      submissionStatus.message?.startsWith(
+                        "benchmark: compiling"
+                      ) ||
+                      submissionStatus.message?.startsWith(
+                        "benchmark: running"
+                      ) ||
+                      submissionStatus.message?.startsWith(
+                        "benchmark: test_result"
+                      ) ||
+                      submissionStatus.status === "CHECKING" ||
+                      submissionStatus.status === "BENCHMARKING" ? (
                         <Spinner size="sm" color="blue.200" />
                       ) : (
                         <Icon
                           as={
                             submissionStatus.status === "ACCEPTED" ||
-                            submissionStatus.message?.startsWith("complete: ACCEPTED")
+                            submissionStatus.message?.startsWith(
+                              "complete: ACCEPTED"
+                            )
                               ? CheckIcon
                               : WarningIcon
                           }


### PR DESCRIPTION
make benchmark results more consistent and accurate. minimal variance between runs, spends a reasonable amount of time on small problems, doesn't spend too long on the large problems
- minimum 1 run or 0.5sec on warmup, same for measured runs

this should account for the problems with long run times (matmul) eating up gpu time, but not have super high variance on the small problems

other misc changes:
- fix ui messages ("Compiling...")