### PR TITLE
 Change "Back to problems" button placement

### DIFF
--- a/src/pages/problems/[slug].tsx
+++ b/src/pages/problems/[slug].tsx
@@ -1176,9 +1176,28 @@ export default function ProblemPage({ slug }: { slug: string }) {
             </VStack>
           ) : (
             <Box>
-              <Heading as="h1" size="lg" mb={2}>
-                {problem.title}
-              </Heading>
+              <HStack justify="space-between" align="center" mb={2}>
+                <Heading as="h1" size="lg">
+                  {problem.title}
+                </Heading>
+                <Button
+                  size="sm"
+                    variant="ghost"
+                    onClick={() => {
+                      window.location.href = "/problems";
+                    }}
+                    leftIcon={<Icon as={FiArrowLeft} />}
+                    borderRadius="full"
+                    color="gray.300"
+                    _hover={{
+                      bg: "whiteAlpha.50",
+                      color: "white",
+                    }}
+                  >
+                    Back to Problems
+                  </Button>
+              </HStack>
+              
               <HStack spacing={2} align="center" mb={6}>
                 <Badge
                   colorScheme={getDifficultyColor(problem.difficulty)}
@@ -1238,6 +1257,7 @@ export default function ProblemPage({ slug }: { slug: string }) {
                   Leaderboard
                 </Button>
               </HStack>
+              
 
               <Box className="markdown" color="gray.100">
                 <ReactMarkdown
@@ -1447,24 +1467,6 @@ export default function ProblemPage({ slug }: { slug: string }) {
               </HStack>
 
               <HStack spacing={2} mt={{ base: 2, sm: 0 }}>
-                {splitRatio < 45 && (
-                  <Button
-                    size="sm"
-                    variant="ghost"
-                    onClick={() => {
-                      window.location.href = "/problems";
-                    }}
-                    leftIcon={<Icon as={FiArrowLeft} />}
-                    borderRadius="full"
-                    color="gray.300"
-                    _hover={{
-                      bg: "whiteAlpha.50",
-                      color: "white",
-                    }}
-                  >
-                    Back to Problems
-                  </Button>
-                )}
                 {isCodeDirty && (
                   <Button
                     size="md"


### PR DESCRIPTION
Given a laptop screen and a slightly extended problem area, the submit button goes off the boundary enabling scroll. This is not ideal. Moved the Back to problems button to be nice.
Before:
<img width="1416" alt="Screenshot 2025-03-14 at 3 08 54 AM" src="https://github.com/user-attachments/assets/4514f395-6704-4679-9637-829d99e9c9e5" />

After:
<img width="1426" alt="Screenshot 2025-03-14 at 3 09 35 AM" src="https://github.com/user-attachments/assets/f3b152de-18d4-4ecc-ac1a-9c3c53788af2" />

Simple change (also helps during coding since I can click submit while monitoring the network tab without scrolling)