### PR TITLE
Adding Time Limit Exceeded Error

### DIFF
--- a/engine/problem.py
+++ b/engine/problem.py
@@ -5,7 +5,7 @@ import torch
 class Problem(ABC):
     """Base class for defining problems."""
     
-    def __init__(self, name: str, time_limit: int = 300):
+    def __init__(self, name: str, time_limit: int = 100):
         """
         Initialize a problem.
         

--- a/engine/problem.py
+++ b/engine/problem.py
@@ -5,7 +5,7 @@ import torch
 class Problem(ABC):
     """Base class for defining problems."""
     
-    def __init__(self, name: str):
+    def __init__(self, name: str, time_limit: int = 300):
         """
         Initialize a problem.
         
@@ -13,6 +13,7 @@ class Problem(ABC):
             name: Name of the problem
         """
         self.name = name
+        self.time_limit = time_limit
     
     @abstractmethod
     def reference_solution(self, *args, **kwargs) -> Any:

--- a/engine/problem.py
+++ b/engine/problem.py
@@ -5,6 +5,7 @@ import torch
 class Problem(ABC):
     """Base class for defining problems."""
     
+    
     def __init__(self, name: str, time_limit: int = 100):
         """
         Initialize a problem.

--- a/engine/runner.py
+++ b/engine/runner.py
@@ -72,7 +72,7 @@ def run_checker(problem_name: str, problem_def: str, compiled: bytes | None, sol
         yield {"status": "running"}
 
         start_time = time.time()
-        time_limit = problem.time_limit if problem.time_limit else 300
+        time_limit = problem.time_limit
 
         # Run each test case
         for test_id, test_case in enumerate(test_cases, 1):

--- a/engine/runner.py
+++ b/engine/runner.py
@@ -80,7 +80,7 @@ def run_checker(problem_name: str, problem_def: str, compiled: bytes | None, sol
                 yield {
                     "status": "error",
                     "error": "Time Limit Exceeded",
-                    "details": f"Execution exceeded time limit",
+                    "details": "Execution exceeded time limit",
                     "test_results": test_results,
                     "passed_tests": passed_tests,
                     "total_tests": total_tests,
@@ -130,7 +130,7 @@ def run_checker(problem_name: str, problem_def: str, compiled: bytes | None, sol
                 yield {
                     "status": "error",
                     "error": "Time Limit Exceeded",
-                    "details": f"Execution exceeded time limit",
+                    "details": "Execution exceeded time limit",
                     "test_results": test_results,
                     "passed_tests": passed_tests,
                     "total_tests": total_tests,

--- a/engine/runner.py
+++ b/engine/runner.py
@@ -10,6 +10,8 @@ import importlib.util
 import tempfile
 import shutil
 import traceback
+import time
+
 
 def run_checker(problem_name: str, problem_def: str, compiled: bytes | None, solution: str | None, dtype: str, language: str) -> Iterator[str]:
     """
@@ -29,8 +31,10 @@ def run_checker(problem_name: str, problem_def: str, compiled: bytes | None, sol
     """
     
     try:
+
         dtype = utils.DTYPE_MAP[dtype]
         problem = utils.load_problem_module(problem_name, problem_def)
+        
 
         if language == "cuda":
             if not compiled:
@@ -67,10 +71,25 @@ def run_checker(problem_name: str, problem_def: str, compiled: bytes | None, sol
 
         yield {"status": "running"}
 
+        start_time = time.time()
+        time_limit = problem.time_limit if problem.time_limit else 300
+
         # Run each test case
         for test_id, test_case in enumerate(test_cases, 1):
+            if time.time() - start_time > time_limit:
+                yield {
+                    "status": "error",
+                    "error": "Time Limit Exceeded",
+                    "details": f"Execution exceeded time limit",
+                    "test_results": test_results,
+                    "passed_tests": passed_tests,
+                    "total_tests": total_tests,
+                }
+                return
+                
             if has_failed:
                 break
+
             test_name = test_case["name"]
             input_tensors = test_case["create_inputs"]()
             
@@ -106,6 +125,17 @@ def run_checker(problem_name: str, problem_def: str, compiled: bytes | None, sol
                 solution_func(*(list(input_tensors) + [actual_output] + list(extra_params)))
 
             torch.cuda.synchronize()
+
+            if time.time() - start_time > time_limit:
+                yield {
+                    "status": "error",
+                    "error": "Time Limit Exceeded",
+                    "details": f"Execution exceeded time limit",
+                    "test_results": test_results,
+                    "passed_tests": passed_tests,
+                    "total_tests": total_tests,
+                }
+                return
 
             # Move to CPU for comparison
             is_correct, debug_info = problem.verify_result(expected_output, actual_output.cpu(), dtype)


### PR DESCRIPTION
Checks if time limit has been exceeded before starting a test case.
Default value is 300s. 

Has been added to the problem definition on a high level, if we need a higher limit on certain problems, we can define it in the problem definition otherwise no change is needed