### PR TITLE
Adding token based Auth for CLI

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@trpc/react-query": "^11.0.0-rc.446",
     "@trpc/server": "^11.0.0-rc.446",
     "@vercel/og": "^0.6.8",
+    "argon2": "^0.43.0",
     "date-fns": "^4.1.0",
     "framer-motion": "^12.4.7",
     "geist": "^1.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       '@vercel/og':
         specifier: ^0.6.8
         version: 0.6.8
+      argon2:
+        specifier: ^0.43.0
+        version: 0.43.0
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
@@ -748,6 +751,10 @@ packages:
   '@panva/hkdf@1.2.1':
     resolution: {integrity: sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==}
 
+  '@phc/format@1.0.0':
+    resolution: {integrity: sha512-m7X9U6BG2+J+R1lSOdCiITLLrxm+cWlNI3HUFA92oLO77ObGNzaKdh8pMLqdZcshtkKuV84olNNXDfMc4FezBQ==}
+    engines: {node: '>=10'}
+
   '@pkgr/core@0.2.0':
     resolution: {integrity: sha512-vsJDAkYR6qCPu+ioGScGiMYR7LvZYIXh/dlQeviqoTWNCVfKTLYD/LkNWH4Mxsv2a5vpIRc77FN5DnmK1eBggQ==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
@@ -1107,6 +1114,10 @@ packages:
 
   arg@5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
+
+  argon2@0.43.0:
+    resolution: {integrity: sha512-u/HKLcbWShVDhkfwI4hWyiUf3qyX8QhTfaIv2cWE18uqhXCmR5hb6Ed7oqYi2KCQegeAnRhiFzbjzm7i5yl1GA==}
+    engines: {node: '>=16.17.0'}
 
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
@@ -2728,9 +2739,17 @@ packages:
       sass:
         optional: true
 
+  node-addon-api@8.3.1:
+    resolution: {integrity: sha512-lytcDEdxKjGJPTLEfW4mYMigRezMlyJY8W4wxJK8zE533Jlb8L8dRuObJFWg2P+AuOIxoCgKF+2Oq4d4Zd0OUA==}
+    engines: {node: ^18 || ^20 || >= 21}
+
   node-cache@5.1.2:
     resolution: {integrity: sha512-t1QzWwnk4sjLWaQAS8CHgOJ+RAfmHpxFWmc36IWTiWHQfs0w5JDMBS1b1ZxQteo0vVVuWJvIUKHDkkeK7vIGCg==}
     engines: {node: '>= 8.0.0'}
+
+  node-gyp-build@4.8.4:
+    resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
+    hasBin: true
 
   npm-run-path@4.0.1:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
@@ -4268,6 +4287,8 @@ snapshots:
 
   '@panva/hkdf@1.2.1': {}
 
+  '@phc/format@1.0.0': {}
+
   '@pkgr/core@0.2.0': {}
 
   '@popperjs/core@2.11.8': {}
@@ -4642,6 +4663,12 @@ snapshots:
   arch@2.2.0: {}
 
   arg@5.0.2: {}
+
+  argon2@0.43.0:
+    dependencies:
+      '@phc/format': 1.0.0
+      node-addon-api: 8.3.1
+      node-gyp-build: 4.8.4
 
   argparse@1.0.10:
     dependencies:
@@ -6791,9 +6818,13 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
+  node-addon-api@8.3.1: {}
+
   node-cache@5.1.2:
     dependencies:
       clone: 2.1.2
+
+  node-gyp-build@4.8.4: {}
 
   npm-run-path@4.0.1:
     dependencies:

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -153,11 +153,14 @@ enum Difficulty {
 }
 
 model ApiKey {
-  id        String    @id @default(cuid())
+  id        String   @id @default(cuid())
   userId    String
+  user      User     @relation(fields: [userId], references: [id])
   name      String
-  key       String    @unique
-  createdAt DateTime  @default(now())
-  expiresAt DateTime?
-  user      User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  keyPrefix String   @unique
+  key       String
+  createdAt DateTime @default(now())
+  expiresAt DateTime
+
+  @@index([expiresAt])
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,16 +8,16 @@ generator client {
 }
 
 model User {
-  id            String    @id @default(cuid())
-  name          String?
-  username      String?
-  email         String?   @unique
-  emailVerified DateTime?
-  image         String?
-  createdAt     DateTime  @default(now())
-  updatedAt     DateTime  @updatedAt
-  refreshToken  String?   @unique
-  lastLogin     DateTime?
+  id             String    @id @default(cuid())
+  name           String?
+  username       String?
+  email          String?   @unique
+  emailVerified  DateTime?
+  image          String?
+  createdAt      DateTime  @default(now())
+  updatedAt      DateTime  @updatedAt
+  refreshToken   String?   @unique
+  lastLogin      DateTime?
   lastLimitReset DateTime?
   currentLimit   Int?
   rating         Int?
@@ -28,6 +28,7 @@ model User {
   submissions  Submission[]
   RevokedToken RevokedToken[]
   Session      Session[]
+  ApiKey       ApiKey[]
 
   @@index([email])
   @@index([createdAt])
@@ -93,10 +94,10 @@ model Problem {
   description String?
   difficulty  Difficulty
   author      String
-  parameters      Json  @default("[]")
+  parameters  Json       @default("[]")
   tags        String[]
 
-  definition  String? @db.Text
+  definition String? @db.Text
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -149,4 +150,14 @@ enum Difficulty {
   MEDIUM
   HARD
   EXPERT
+}
+
+model ApiKey {
+  id        String    @id @default(cuid())
+  userId    String
+  name      String
+  key       String    @unique
+  createdAt DateTime  @default(now())
+  expiresAt DateTime?
+  user      User      @relation(fields: [userId], references: [id], onDelete: Cascade)
 }

--- a/src/pages/[username].tsx
+++ b/src/pages/[username].tsx
@@ -137,13 +137,12 @@ export default function UserProfile() {
                   endColor="gray.800"
                   borderRadius="xl"
                 >
-                  {userData?.activityData &&
-                    userData.activityData.length > 0 && (
-                      <ActivityCalendar
-                        data={userData.activityData as ActivityItem[]}
-                        joinedYear={joinedYear}
-                      />
-                    )}
+                  {userData?.activityData && (
+                    <ActivityCalendar
+                      data={userData.activityData as ActivityItem[]}
+                      joinedYear={joinedYear}
+                    />
+                  )}
                 </Skeleton>
               </Box>
 

--- a/src/pages/api/api-keys/index.ts
+++ b/src/pages/api/api-keys/index.ts
@@ -3,7 +3,25 @@ import { type NextApiRequest, type NextApiResponse } from "next";
 import { getServerSession } from "next-auth/next";
 import { authConfig } from "~/server/auth/config";
 import crypto from "crypto";
+import argon2 from "argon2";
 import { db } from "~/server/db";
+
+const generateApiKey = () => {
+  const prefix = crypto.randomBytes(6).toString("hex");
+  const keyBody = crypto.randomBytes(28).toString("hex");
+  return {
+    fullKey: `tsra_${prefix}_${keyBody}`,
+    prefix,
+    keyBody,
+  };
+};
+
+const argon2Options = {
+  type: argon2.argon2id,
+  memoryCost: 4096,
+  timeCost: 2,
+  parallelism: 1,
+};
 
 export default async function handler(
   req: NextApiRequest,
@@ -35,25 +53,24 @@ export default async function handler(
       expiresIn?: number;
     };
 
-    if (!name) {
-      return res.status(400).json({ error: "Name is required" });
+    if (!name || name.length < 3 || typeof name !== "string") {
+      return res
+        .status(400)
+        .json({ error: "Name must be at least 3 characters long" });
     }
 
-    const apiKeyValue = `tsra_${crypto.randomBytes(32).toString("hex")}`;
-
-    const hashedKey = crypto
-      .createHash("sha256")
-      .update(apiKeyValue)
-      .digest("hex");
+    const { fullKey, prefix, keyBody } = generateApiKey();
+    const hashedKey = await argon2.hash(keyBody, argon2Options);
 
     const expiresAt = expiresIn
       ? new Date(Date.now() + expiresIn)
-      : new Date(Date.now() + 30 * 24 * 60 * 60 * 1000); //if no expiration date is provided, it will default to 30 days
+      : new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
 
     const apiKey = await db.apiKey.create({
       data: {
         userId: session.user.id,
         name,
+        keyPrefix: prefix,
         key: hashedKey,
         expiresAt,
       },
@@ -62,7 +79,7 @@ export default async function handler(
     return res.status(201).json({
       id: apiKey.id,
       name: apiKey.name,
-      key: apiKeyValue,
+      key: fullKey,
       createdAt: apiKey.createdAt,
       expiresAt: apiKey.expiresAt,
     });

--- a/src/pages/api/api-keys/index.ts
+++ b/src/pages/api/api-keys/index.ts
@@ -1,0 +1,72 @@
+// pages/api/api-keys/index.ts
+import { type NextApiRequest, type NextApiResponse } from "next";
+import { getServerSession } from "next-auth/next";
+import { authConfig } from "~/server/auth/config";
+import crypto from "crypto";
+import { db } from "~/server/db";
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  const session = await getServerSession(req, res, authConfig);
+
+  if (!session?.user?.id) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+
+  if (req.method === "GET") {
+    const apiKeys = await db.apiKey.findMany({
+      where: { userId: session.user.id },
+      select: {
+        id: true,
+        name: true,
+        createdAt: true,
+        expiresAt: true,
+      },
+    });
+
+    return res.status(200).json(apiKeys);
+  }
+
+  if (req.method === "POST") {
+    const { name, expiresIn } = req.body as {
+      name: string;
+      expiresIn?: number;
+    };
+
+    if (!name) {
+      return res.status(400).json({ error: "Name is required" });
+    }
+
+    const apiKeyValue = `tsra_${crypto.randomBytes(32).toString("hex")}`;
+
+    const hashedKey = crypto
+      .createHash("sha256")
+      .update(apiKeyValue)
+      .digest("hex");
+
+    const expiresAt = expiresIn
+      ? new Date(Date.now() + expiresIn)
+      : new Date(Date.now() + 30 * 24 * 60 * 60 * 1000); //if no expiration date is provided, it will default to 30 days
+
+    const apiKey = await db.apiKey.create({
+      data: {
+        userId: session.user.id,
+        name,
+        key: hashedKey,
+        expiresAt,
+      },
+    });
+
+    return res.status(201).json({
+      id: apiKey.id,
+      name: apiKey.name,
+      key: apiKeyValue,
+      createdAt: apiKey.createdAt,
+      expiresAt: apiKey.expiresAt,
+    });
+  }
+
+  return res.status(405).json({ error: "Method not allowed" });
+}

--- a/src/pages/api/test/cliTest.ts
+++ b/src/pages/api/test/cliTest.ts
@@ -1,0 +1,18 @@
+// pages/api/protected-data.ts
+import { type NextApiRequest, type NextApiResponse } from "next";
+import { combinedAuth } from "~/server/auth";
+
+async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const authResult = await combinedAuth(req, res);
+  if (!authResult) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+  return res.status(200).json({
+    success: true,
+    userId: authResult.user.id,
+    message: `Hello, ${authResult.user.name ?? "User"}! This is protected data.`,
+    timestamp: new Date().toISOString(),
+  });
+}
+
+export default handler;

--- a/src/pages/api/test/cliTest.ts
+++ b/src/pages/api/test/cliTest.ts
@@ -4,6 +4,9 @@ import { combinedAuth } from "~/server/auth";
 
 async function handler(req: NextApiRequest, res: NextApiResponse) {
   const authResult = await combinedAuth(req, res);
+  if (authResult && "error" in authResult) {
+    return res.status(401).json({ error: authResult.error });
+  }
   if (!authResult) {
     return res.status(401).json({ error: "Unauthorized" });
   }

--- a/src/server/auth/index.ts
+++ b/src/server/auth/index.ts
@@ -50,12 +50,6 @@ export const authAPIKey = async (
       return { error: "Invalid API key" };
     }
 
-    if (apiKeyRecord.expiresAt && apiKeyRecord.expiresAt < new Date()) {
-      return {
-        error: "API key expired, generate a new one at https://tensara.org",
-      };
-    }
-
     try {
       const matches = await argon2.verify(apiKeyRecord.key, body);
       if (!matches) {
@@ -64,6 +58,12 @@ export const authAPIKey = async (
     } catch (err) {
       console.error("API key verification error:", err);
       return { error: "Invalid API key" };
+    }
+
+    if (apiKeyRecord.expiresAt && apiKeyRecord.expiresAt < new Date()) {
+      return {
+        error: "API key expired, generate a new one at https://tensara.org",
+      };
     }
 
     const session = {

--- a/src/server/auth/index.ts
+++ b/src/server/auth/index.ts
@@ -17,7 +17,11 @@ export const auth = (
 export const authAPIKey = async (
   authorization?: string
 ): Promise<Session | null> => {
-  if (!authorization?.startsWith("Bearer ")) {
+  if (!authorization) {
+    return null;
+  }
+
+  if (!authorization.startsWith("Bearer ")) {
     return null;
   }
 

--- a/src/server/auth/index.ts
+++ b/src/server/auth/index.ts
@@ -1,6 +1,8 @@
-import { getServerSession } from "next-auth";
+import { getServerSession, type Session } from "next-auth";
 import { type GetServerSidePropsContext } from "next";
 import { authConfig } from "./config";
+import { db } from "../db";
+import crypto from "crypto";
 
 export const auth = (
   req?: GetServerSidePropsContext["req"],
@@ -11,4 +13,51 @@ export const auth = (
   }
   return null;
 };
+
+export const authAPIKey = async (
+  authorization?: string
+): Promise<Session | null> => {
+  if (!authorization?.startsWith("Bearer ")) {
+    return null;
+  }
+
+  try {
+    const apiKey = authorization.substring(7); // Remove "Bearer " prefix
+    const hashedApiKey = crypto
+      .createHash("sha256")
+      .update(apiKey)
+      .digest("hex");
+
+    const apiRecord = await db.apiKey.findUnique({
+      where: { key: hashedApiKey },
+      include: { user: true },
+    });
+
+    if (
+      apiRecord?.user &&
+      apiRecord.expiresAt &&
+      apiRecord.expiresAt >= new Date()
+    ) {
+      const session = {
+        user: apiRecord.user,
+        expires: apiRecord.expiresAt.toISOString(),
+      } as Session;
+      return session;
+    }
+  } catch (error) {
+    console.error("API key authentication error:", error);
+  }
+
+  return null;
+};
+
+export const combinedAuth = async (
+  req?: GetServerSidePropsContext["req"],
+  res?: GetServerSidePropsContext["res"]
+) => {
+  return (
+    (await auth(req, res)) ?? (await authAPIKey(req?.headers.authorization))
+  );
+};
+
 export { authConfig as config };


### PR DESCRIPTION
Using argon2 for hashing. Using a 6 byte prefix and a 28 byte key for the key. First, search by the prefix and then match the hash for auth. Should be robust. 

Added a combinedAuth function. For any endpoint that we want to allow api key auth, we can just replace the existing auth function with this and it will just work.

Added a nit for activity calendar. Display it even if there are no submissions.