### PR TITLE
improvement: use a single api call for submitting

### DIFF
--- a/src/components/problem/SplitPanel.tsx
+++ b/src/components/problem/SplitPanel.tsx
@@ -105,11 +105,6 @@ const SplitPanel = ({
         zIndex={2}
         onClick={(e) => e.stopPropagation()}
         onMouseDown={handleMouseDown}
-        _hover={{
-          "& > div": {
-            bg: "whiteAlpha.400",
-          },
-        }}
       >
         <Box
           position="absolute"

--- a/src/hooks/useSubmissionStream.ts
+++ b/src/hooks/useSubmissionStream.ts
@@ -42,7 +42,6 @@ export function useSubmissionStream(refetchSubmissions: () => void) {
     BenchmarkResultResponse[]
   >([]);
   const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
-  const [submissionId, setSubmissionId] = useState<string | null>(null);
   const [isTestCaseTableOpen, setIsTestCaseTableOpen] =
     useState<boolean>(false);
   const [isBenchmarking, setIsBenchmarking] = useState<boolean>(false);
@@ -275,16 +274,19 @@ export function useSubmissionStream(refetchSubmissions: () => void) {
   );
 
   const processSubmission = useCallback(
-    async (id: string) => {
-      setSubmissionId(id);
-
+    async (submissionData: {
+      code: string;
+      language: string;
+      gpuType: string;
+      problemSlug: string;
+    }) => {
       try {
         const response = await fetch("/api/submissions/direct-submit", {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
           },
-          body: JSON.stringify({ submissionId: id }),
+          body: JSON.stringify(submissionData),
           cache: "no-store",
           credentials: "same-origin",
           keepalive: true,
@@ -347,7 +349,6 @@ export function useSubmissionStream(refetchSubmissions: () => void) {
     metaResponse,
     testResults,
     benchmarkResults,
-    submissionId,
     isTestCaseTableOpen,
     isBenchmarking,
     setIsTestCaseTableOpen,

--- a/src/hooks/useSubmissionStream.ts
+++ b/src/hooks/useSubmissionStream.ts
@@ -127,11 +127,8 @@ export function useSubmissionStream(refetchSubmissions: () => void) {
             break;
 
           case "BENCHMARK_RESULT":
-            // Set benchmark flags when we start receiving benchmark results
-            if (!isBenchmarking) {
-              setIsBenchmarking(true);
-              setIsTestCaseTableOpen(true);
-            }
+            setIsBenchmarking(true);
+            setIsTestCaseTableOpen(true);
 
             const benchmarkResultData = JSON.parse(
               eventData
@@ -207,7 +204,7 @@ export function useSubmissionStream(refetchSubmissions: () => void) {
         );
       }
     },
-    [isBenchmarking, refetchSubmissions, toast]
+    [refetchSubmissions, toast]
   );
 
   const processEventStream = useCallback(

--- a/src/pages/api/submissions/direct-submit.ts
+++ b/src/pages/api/submissions/direct-submit.ts
@@ -41,9 +41,14 @@ export default async function handler(
     gpuType: string;
   };
 
-  if (!problemSlug || !code || !language || !gpuType) {
+  const requiredFields = { problemSlug, code, language, gpuType };
+  const missingFields = Object.entries(requiredFields).filter(
+    ([_, value]) => value === undefined
+  );
+
+  if (missingFields.length > 0) {
     res.status(400).json({
-      error: "Missing required fields, please raise an issue if this persists",
+      error: `Missing required fields: ${missingFields.map(([key]) => key).join(", ")}`,
     });
     return;
   }

--- a/src/pages/api/submissions/direct-submit.ts
+++ b/src/pages/api/submissions/direct-submit.ts
@@ -34,23 +34,36 @@ export default async function handler(
     return;
   }
 
-  const { submissionId } = req.body as { submissionId: string };
+  const { problemSlug, code, language, gpuType } = req.body as {
+    problemSlug: string;
+    code: string;
+    language: string;
+    gpuType: string;
+  };
 
-  if (!submissionId) {
-    res.status(400).json({ error: "Missing submissionId" });
+  if (!problemSlug || !code || !language || !gpuType) {
+    res.status(400).json({
+      error: "Missing required fields, please raise an issue if this persists",
+    });
     return;
   }
 
   const rateLimit = await checkRateLimit(session.user.id);
   if (!rateLimit.allowed) {
-    await db.submission.deleteMany({
-      where: { id: submissionId },
-    });
     res.status(rateLimit.statusCode ?? 429).json({
       status: SubmissionError.RATE_LIMIT_EXCEEDED as SubmissionErrorType,
       error: rateLimit.error,
       details: rateLimit.error,
     });
+    return;
+  }
+
+  const problem = await db.problem.findUnique({
+    where: { slug: problemSlug },
+  });
+
+  if (!problem) {
+    res.status(404).json({ error: "Problem not found" });
     return;
   }
 
@@ -94,14 +107,21 @@ export default async function handler(
     }
   }, 30000);
 
-  try {
-    const submission = await db.submission.findUnique({
-      where: { id: submissionId },
-      include: {
-        problem: true,
-      },
-    });
+  const submission = await db.submission.create({
+    data: {
+      code,
+      language,
+      gpuType: gpuType || "T4",
+      status: SubmissionStatus.IN_QUEUE,
+      problem: { connect: { id: problem.id } },
+      user: { connect: { id: session.user.id } },
+    },
+    include: {
+      problem: true,
+    },
+  });
 
+  try {
     if (!submission) {
       res.status(404).json({ error: "Submission not found" });
       return;
@@ -114,7 +134,7 @@ export default async function handler(
 
     // TODO:
     await db.submission.update({
-      where: { id: submissionId },
+      where: { id: submission.id },
       data: {
         status: SubmissionStatus.CHECKING,
       },
@@ -485,10 +505,10 @@ export default async function handler(
   } catch (error) {
     console.error("Error in direct-submit handler:", error);
 
-    if (submissionId) {
+    if (submission.id) {
       try {
         await db.submission.update({
-          where: { id: submissionId },
+          where: { id: submission.id },
           data: {
             status: SubmissionError.ERROR,
             errorMessage:

--- a/src/pages/api/submissions/direct-submit.ts
+++ b/src/pages/api/submissions/direct-submit.ts
@@ -227,6 +227,9 @@ export default async function handler(
             const parsed = JSON.parse(response_json) as {
               status: string;
             };
+            if (!parsed) {
+              continue;
+            }
             const response_status = parsed.status;
 
             if (response_status === SubmissionStatus.TEST_RESULT) {
@@ -433,6 +436,9 @@ export default async function handler(
             const parsed = JSON.parse(response_json) as {
               status: string;
             };
+            if (!parsed) {
+              continue;
+            }
             const response_status = parsed.status;
 
             if (response_status === SubmissionStatus.BENCHMARK_RESULT) {

--- a/src/pages/problems/[slug].tsx
+++ b/src/pages/problems/[slug].tsx
@@ -7,14 +7,12 @@ import {
   useToast,
   Icon,
   Heading,
-  Container,
 } from "@chakra-ui/react";
 import { useSession } from "next-auth/react";
 import superjson from "superjson";
 
 import type { GetServerSideProps } from "next";
 import { type Problem, type Submission } from "@prisma/client";
-import { SubmissionError } from "~/types/submission";
 
 import { Layout } from "~/components/layout";
 import MySubmissions from "~/components/problem/MySubmissions";
@@ -118,27 +116,9 @@ export default function ProblemPage({ slug }: { slug: string }) {
     setIsTestCaseTableOpen,
     processSubmission,
     startSubmission,
-    setMetaStatus,
     totalTests,
     getTypedResponse,
   } = useSubmissionStream(submissionsQuery.refetch);
-
-  // Create submission mutation
-  const createSubmissionMutation = api.problems.createSubmission.useMutation({
-    onSuccess: (data) => {
-      void processSubmission(data.id);
-    },
-    onError: (error) => {
-      setMetaStatus(SubmissionError.ERROR);
-      toast({
-        title: "Failed to create submission",
-        description: error.message,
-        status: "error",
-        duration: 5000,
-        isClosable: true,
-      });
-    },
-  });
 
   // Handle submission
   const handleSubmit = useCallback(() => {
@@ -168,7 +148,7 @@ export default function ProblemPage({ slug }: { slug: string }) {
     startSubmission();
     setViewType("result");
 
-    createSubmissionMutation.mutate({
+    void processSubmission({
       problemSlug: slug,
       code: code,
       language: selectedLanguage,
@@ -180,7 +160,7 @@ export default function ProblemPage({ slug }: { slug: string }) {
     code,
     selectedLanguage,
     selectedGpuType,
-    createSubmissionMutation,
+    processSubmission,
     startSubmission,
     setViewType,
     toast,


### PR DESCRIPTION
### Current
When a user submits:
1. We make call to: `https://tensara.org/api/trpc/problems.createSubmission?batch=1` with
   - Body:
     ```
     code: "code"
     gpuType: "T4"
     language: "cuda"
     problemSlug: "avg-pool-1d"
     ```

2. When successful, second call is made to : `https://tensara.org/api/submissions/direct-submit` with
   - Body:
     ```
     submissionId: "id" (from first response)
     ```
     
This is weird.

### Now 
Using a single endpoint:
- Endpoint: `http://localhost:3000/api/submissions/direct-submit`
- Body: Same payload as originally sent to first endpoint
  ```
  code: "code"
  gpuType: "T4"
  language: "cuda"
  problemSlug: "avg-pool-1d"
  ```
This has reduced complexity, improved latency (fewer round trips) and now we can integrate CLI easily