### PR TITLE
Fix: issue #107, case insensitive Github usernames

### DIFF
--- a/src/server/api/routers/users.ts
+++ b/src/server/api/routers/users.ts
@@ -188,7 +188,7 @@ export const usersRouter = createTRPCRouter({
     .input(z.object({ username: z.string() }))
     .query(async ({ ctx, input }) => {
       const user = await ctx.db.user.findFirst({
-        where: { username: input.username },
+        where: { username: {equals: input.username, mode: 'insensitive'} },
         select: {
           id: true,
           name: true,


### PR DESCRIPTION
Use mode insensitive which is Prisma's case-insensitve operation

Tested with own account: name: ChinmayBansal
chinmaybansal
Chinmaybansal
CHINMAYBANSAL


All worked