### PR TITLE
add CuTe DSL Support

### DIFF
--- a/engine/api.py
+++ b/engine/api.py
@@ -50,7 +50,7 @@ def build_runtime_image(gpu: str):
             .run_commands("curl -LsSf https://astral.sh/uv/install.sh | sh")
             .run_commands(UV_PREFIX + " ".join(PIP_PACKAGES))
             .run_commands(
-                "uv pip install --system modular --extra-index-url https://dl.modular.com/public/nightly/python/simple/ --index-strategy unsafe-best-match"
+                "uv pip install --system modular==25.4.0"
             )
             .add_local_python_source(*LOCAL_SOURCE)
         )

--- a/engine/api.py
+++ b/engine/api.py
@@ -49,9 +49,7 @@ def build_runtime_image(gpu: str):
             .env({"PATH": "/root/.local/bin:$PATH"})
             .run_commands("curl -LsSf https://astral.sh/uv/install.sh | sh")
             .run_commands(UV_PREFIX + " ".join(PIP_PACKAGES))
-            .run_commands(
-                "uv pip install --system modular==25.4.0"
-            )
+            .run_commands("uv pip install --system modular==25.4.0")
             .add_local_python_source(*LOCAL_SOURCE)
         )
 
@@ -86,7 +84,9 @@ def binary_runner(
     if type == "sandbox":
         gen = runner.run_sandbox(compiled_lib, solution_code)
     elif type == "sample":
-        gen = runner.run_sample_case(problem_name, problem_def, solution_code, compiled_lib, dtype, language)
+        gen = runner.run_sample_case(
+            problem_name, problem_def, solution_code, compiled_lib, dtype, language
+        )
     else:
         try:
             problem = utils.load_problem_module(problem_name, problem_def)

--- a/engine/api.py
+++ b/engine/api.py
@@ -11,13 +11,13 @@ RUNTIME_IMAGE_NAME = "nvidia/cuda:12.8.0-runtime-ubuntu22.04"
 CURR_DIR = Path(__file__).parent
 
 
-PIP_PACKAGES = ["torch", "numpy", "fastapi", "triton", "simplejson"]
+PIP_PACKAGES = ["torch", "numpy", "fastapi", "triton", "simplejson", "nvidia-cutlass-dsl"]
 UV_PREFIX = "uv pip install --system "
 LOCAL_SOURCE = ["utils", "runner", "problem", "api"]
 APT_PACKAGES = ["build-essential", "gcc", "g++", "curl"]
 
 devel_image = (
-    modal.Image.from_registry(DEVEL_IMAGE_NAME, add_python="3.11")
+    modal.Image.from_registry(DEVEL_IMAGE_NAME, add_python="3.12")
     .apt_install(APT_PACKAGES)
     .env({"CC": "gcc"})
     .env({"PATH": "/root/.local/bin:$PATH"})
@@ -30,7 +30,7 @@ devel_image = (
 def build_runtime_image(gpu: str):
     if gpu == "B200":
         return (
-            modal.Image.from_registry(RUNTIME_IMAGE_NAME, add_python="3.11")
+            modal.Image.from_registry(RUNTIME_IMAGE_NAME, add_python="3.12")
             .apt_install(APT_PACKAGES + ["libedit-dev", "zlib1g-dev"])
             .env({"CC": "gcc"})
             .env({"PATH": "/root/.local/bin:$PATH"})
@@ -43,7 +43,7 @@ def build_runtime_image(gpu: str):
         )
     else:
         return (
-            modal.Image.from_registry(RUNTIME_IMAGE_NAME, add_python="3.11")
+            modal.Image.from_registry(RUNTIME_IMAGE_NAME, add_python="3.12")
             .apt_install(APT_PACKAGES + ["libedit-dev", "zlib1g-dev"])
             .env({"CC": "gcc"})
             .env({"PATH": "/root/.local/bin:$PATH"})
@@ -85,6 +85,8 @@ def binary_runner(
 
     if type == "sandbox":
         gen = runner.run_sandbox(compiled_lib, solution_code)
+    elif type == "sample":
+        gen = runner.run_sample_case(problem_name, problem_def, solution_code, compiled_lib, dtype, language)
     else:
         try:
             problem = utils.load_problem_module(problem_name, problem_def)
@@ -98,7 +100,8 @@ def binary_runner(
             return
 
         if type == "sample":
-            gen = runner.run_sample_case(problem_name, problem_def, solution_func, dtype, language)
+            # this should not be reached
+            raise ValueError("This code path should not be reached")
         elif type == "checker":
             gen = runner.run_checker(problem_name, problem_def, solution_func, dtype, language)
         elif type == "benchmark":

--- a/engine/runner.py
+++ b/engine/runner.py
@@ -28,6 +28,7 @@ def run_checker(
         solution_func: Callable function for the submitted solution
         dtype: Data type for the problem
         language: Programming language of the solution ("cuda", "python", or "mojo")
+        param_func: None for general submissions, non-None only for baseline submissions
 
     Returns:
         Iterator that yields JSON strings with test results
@@ -165,15 +166,16 @@ def run_checker(
         }
 
 
-@utils.subproc_generator(timeout=60)
-def run_sample_case(problem_name, problem_def, solution_func, dtype, language, param_func=None):
+@utils.subproc_generator(timeout=60)  
+def run_sample_case(problem_name, problem_def, solution_code, compiled_lib, dtype, language, param_func=None):
     """
     Run the sample test case of a problem and return result + output.
     """
     try:
         dtype = utils.DTYPE_MAP[dtype]
         problem = utils.load_problem_module(problem_name, problem_def)
-
+        solution_func = utils.make_solution_func(language, solution_code, compiled_lib, problem)
+        
         sample = problem.generate_sample(dtype)
         input_tensors = sample["create_inputs"]()
         expected_output = problem.reference_solution(*input_tensors).cpu()

--- a/engine/runner.py
+++ b/engine/runner.py
@@ -166,8 +166,10 @@ def run_checker(
         }
 
 
-@utils.subproc_generator(timeout=60)  
-def run_sample_case(problem_name, problem_def, solution_code, compiled_lib, dtype, language, param_func=None):
+@utils.subproc_generator(timeout=60)
+def run_sample_case(
+    problem_name, problem_def, solution_code, compiled_lib, dtype, language, param_func=None
+):
     """
     Run the sample test case of a problem and return result + output.
     """
@@ -175,7 +177,7 @@ def run_sample_case(problem_name, problem_def, solution_code, compiled_lib, dtyp
         dtype = utils.DTYPE_MAP[dtype]
         problem = utils.load_problem_module(problem_name, problem_def)
         solution_func = utils.make_solution_func(language, solution_code, compiled_lib, problem)
-        
+
         sample = problem.generate_sample(dtype)
         input_tensors = sample["create_inputs"]()
         expected_output = problem.reference_solution(*input_tensors).cpu()

--- a/engine/tests/submit.sh
+++ b/engine/tests/submit.sh
@@ -10,10 +10,13 @@ elif [[ "$1" == "--cuda" ]]; then
 elif [[ "$1" == "--mojo" ]]; then
   mode="mojo"
   shift
+elif [[ "$1" == "--cute" ]]; then
+  mode="cute"
+  shift
 fi
 
 if [ $# -lt 1 ]; then
-  echo "Usage: $0 [--triton|--cuda|--mojo] <problem_name> [api_endpoint]"
+  echo "Usage: $0 [--python|--cuda|--mojo|--cute] <problem_name> [api_endpoint]"
   echo "Example: $0 --cuda matrix_multiplication https://api.example.com/submit"
   exit 1
 fi
@@ -33,6 +36,10 @@ case $mode in
   "mojo")
     solution_file="solution.mojo"
     language="mojo"
+    ;;
+  "cute")
+    solution_file="solution.py"
+    language="cute"
     ;;
 esac
 

--- a/engine/utils.py
+++ b/engine/utils.py
@@ -254,6 +254,7 @@ def cast_to_ctype(data, argtypes, language="cuda"):
     else:
         return data
 
+
 def cast_to_cute(data):
     """Cast data to CuTe tensors"""
     from cutlass.cute.runtime import from_dlpack
@@ -360,6 +361,7 @@ def run_dynamic_benchmark(
 
     if language == "cute":
         import cutlass.cute as cute
+
         solution_func = cute.compile(solution_func, *parameters)
 
     # Calculate FLOPS for this test case
@@ -523,7 +525,7 @@ def make_solution_func(language: str, solution_code: str, compiled: bytes, probl
         module = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(module)
         return module.solution
-    
+
     else:
         raise ValueError(f"Unsupported language: {language}")
 
@@ -541,6 +543,7 @@ def make_parameters(language: str, solution_func, input_tensors, actual_output, 
         return input_ptrs + [output_ptr] + extra_params_casted
     elif language == "cute":
         from cutlass.cute.runtime import from_dlpack
+
         input_ptrs = cast_to_cute(input_tensors)
         output_ptr = from_dlpack(actual_output, assumed_align=16)
         extra_params = problem.get_extra_params(test_case)

--- a/engine/utils.py
+++ b/engine/utils.py
@@ -254,6 +254,18 @@ def cast_to_ctype(data, argtypes, language="cuda"):
     else:
         return data
 
+def cast_to_cute(data):
+    """Cast data to CuTe tensors"""
+    from cutlass.cute.runtime import from_dlpack
+
+    data_casted = []
+    for tensor in data:
+        if isinstance(tensor, torch.Tensor):
+            data_casted.append(from_dlpack(tensor, assumed_align=16))
+        else:
+            data_casted.append(tensor)
+    return data_casted
+
 
 def load_problem_module(problem_type: str, problem_def: str = None) -> Problem:
     """
@@ -345,6 +357,10 @@ def run_dynamic_benchmark(
         parameters = param_func(
             language, solution_func, input_tensors, actual_output, problem, test_case
         )
+
+    if language == "cute":
+        import cutlass.cute as cute
+        solution_func = cute.compile(solution_func, *parameters)
 
     # Calculate FLOPS for this test case
     flops = problem.get_flops(test_case)
@@ -491,21 +507,23 @@ def make_solution_func(language: str, solution_code: str, compiled: bytes, probl
         mojo_lib.solution.restype = func_sig["restype"]
         return mojo_lib.solution
 
-    elif language == "python":
+    elif language == "python" or language == "cute":
+        filename = "triton_solution.py" if language == "python" else "cute_solution.py"
         if not solution_code:
             raise ValueError("Source code required for Triton submissions")
 
         temp_dir = tempfile.mkdtemp()
-        temp_path = os.path.join(temp_dir, "triton_solution.py")
+        temp_path = os.path.join(temp_dir, filename)
 
         # This is needed because @jit has to read the source code
         with open(temp_path, "w") as f:
             f.write(solution_code)
 
-        spec = importlib.util.spec_from_file_location("triton_solution", temp_path)
+        spec = importlib.util.spec_from_file_location(filename, temp_path)
         module = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(module)
         return module.solution
+    
     else:
         raise ValueError(f"Unsupported language: {language}")
 
@@ -520,6 +538,13 @@ def make_parameters(language: str, solution_func, input_tensors, actual_output, 
         extra_params_casted = cast_to_ctype(
             extra_params, solution_func.argtypes[-len(extra_params) :], language
         )
+        return input_ptrs + [output_ptr] + extra_params_casted
+    elif language == "cute":
+        from cutlass.cute.runtime import from_dlpack
+        input_ptrs = cast_to_cute(input_tensors)
+        output_ptr = from_dlpack(actual_output, assumed_align=16)
+        extra_params = problem.get_extra_params(test_case)
+        extra_params_casted = cast_to_cute(extra_params)
         return input_ptrs + [output_ptr] + extra_params_casted
     else:
         extra_params = problem.get_extra_params(test_case)

--- a/src/components/problem/SubmissionForm.tsx
+++ b/src/components/problem/SubmissionForm.tsx
@@ -116,17 +116,6 @@ const SubmissionForm = ({
                     fontSize="sm"
                   >
                     {value}
-                    {(key === "H200" || key === "B200") && (
-                      <Badge
-                        ml={2}
-                        colorScheme="cyan"
-                        fontSize="2xs"
-                        variant="subtle"
-                        rounded="sm"
-                      >
-                        NEW
-                      </Badge>
-                    )}
                   </MenuItem>
                 ))}
             </MenuList>
@@ -205,18 +194,20 @@ const SubmissionForm = ({
                   }
                   fontSize="sm"
                 >
-                  Mojo{" "}
-                  <Badge
-                    ml={1}
-                    colorScheme="cyan"
-                    fontSize="2xs"
-                    variant="subtle"
-                    rounded="sm"
-                  >
-                    BETA
-                  </Badge>
+                  Mojo
                 </MenuItem>
               </Tooltip>
+              <MenuItem
+                key="cute"
+                onClick={() => setSelectedLanguage("cute")}
+                bg="brand.secondary"
+                _hover={{ bg: "gray.700" }}
+                color="white"
+                borderRadius="lg"
+                fontSize="sm"
+              >
+                CuTe DSL
+              </MenuItem>
             </MenuList>
           </Menu>
         </Box>

--- a/src/components/problem/SubmissionForm.tsx
+++ b/src/components/problem/SubmissionForm.tsx
@@ -109,10 +109,7 @@ const SubmissionForm = ({
                     _hover={{ bg: "gray.700" }}
                     color="white"
                     borderRadius="lg"
-                    isDisabled={
-                      (key === "B200") &&
-                      selectedLanguage === "mojo"
-                    }
+                    isDisabled={key === "B200" && selectedLanguage === "mojo"}
                     fontSize="sm"
                   >
                     {value}
@@ -175,9 +172,7 @@ const SubmissionForm = ({
               </MenuItem>
               <Tooltip
                 label="Mojo does not support NVIDIA B200 GPUs yet"
-                isDisabled={
-                  selectedGpuType !== "B200"
-                }
+                isDisabled={selectedGpuType !== "B200"}
                 placement="right"
                 hasArrow
                 bg="gray.700"
@@ -189,9 +184,7 @@ const SubmissionForm = ({
                   _hover={{ bg: "gray.700" }}
                   color="white"
                   borderRadius="lg"
-                  isDisabled={
-                    selectedGpuType === "B200"
-                  }
+                  isDisabled={selectedGpuType === "B200"}
                   fontSize="sm"
                 >
                   Mojo

--- a/src/components/problem/SubmissionForm.tsx
+++ b/src/components/problem/SubmissionForm.tsx
@@ -110,7 +110,7 @@ const SubmissionForm = ({
                     color="white"
                     borderRadius="lg"
                     isDisabled={
-                      (key === "T4" || key === "B200") &&
+                      (key === "B200") &&
                       selectedLanguage === "mojo"
                     }
                     fontSize="sm"
@@ -174,9 +174,9 @@ const SubmissionForm = ({
                 Triton
               </MenuItem>
               <Tooltip
-                label="Mojo does not support NVIDIA T4 or B200 GPUs"
+                label="Mojo does not support NVIDIA B200 GPUs yet"
                 isDisabled={
-                  selectedGpuType !== "T4" && selectedGpuType !== "B200"
+                  selectedGpuType !== "B200"
                 }
                 placement="right"
                 hasArrow
@@ -190,7 +190,7 @@ const SubmissionForm = ({
                   color="white"
                   borderRadius="lg"
                   isDisabled={
-                    selectedGpuType === "T4" || selectedGpuType === "B200"
+                    selectedGpuType === "B200"
                   }
                   fontSize="sm"
                 >
@@ -207,6 +207,15 @@ const SubmissionForm = ({
                 fontSize="sm"
               >
                 CuTe DSL
+                <Badge
+                  ml={2}
+                  colorScheme="cyan"
+                  fontSize="2xs"
+                  variant="subtle"
+                  rounded="sm"
+                >
+                  NEW
+                </Badge>
               </MenuItem>
             </MenuList>
           </Menu>

--- a/src/constants/datatypes.ts
+++ b/src/constants/datatypes.ts
@@ -46,3 +46,16 @@ export const MOJO_MISC_TYPES: Record<string, string> = {
   int: "Int32",
   size_t: "Int32",
 } as const;
+
+export const CUTE_TYPES: Record<DataType, string> = {
+  float32: "cute.Float32",
+  float16: "cute.Float16",
+  int32: "cute.Int32",
+  int16: "cute.Int16",
+} as const;
+
+export const CUTE_MISC_TYPES: Record<string, string> = {
+  float: "cute.Float32",
+  int: "cute.Int32",
+  size_t: "cute.Int32",
+} as const;

--- a/src/constants/language.ts
+++ b/src/constants/language.ts
@@ -3,12 +3,12 @@ export const LANGUAGE_DISPLAY_NAMES: Record<string, string> = {
   cuda: "CUDA C++",
   python: "Triton",
   mojo: "Mojo",
-  cute: "CuTe DSL"  
+  cute: "CuTe DSL",
 } as const;
 
 export const LANGUAGE_PROFILE_DISPLAY_NAMES: Record<string, string> = {
   cuda: "CUDA",
   python: "Triton",
   mojo: "Mojo",
-  cute: "CuTe"
+  cute: "CuTe",
 } as const;

--- a/src/constants/language.ts
+++ b/src/constants/language.ts
@@ -3,16 +3,12 @@ export const LANGUAGE_DISPLAY_NAMES: Record<string, string> = {
   cuda: "CUDA C++",
   python: "Triton",
   mojo: "Mojo",
+  cute: "CuTe DSL"  
 } as const;
 
 export const LANGUAGE_PROFILE_DISPLAY_NAMES: Record<string, string> = {
   cuda: "CUDA",
   python: "Triton",
   mojo: "Mojo",
-} as const;
-
-export const IS_DISABLED_LANGUAGE: Record<string, boolean> = {
-  cuda: false,
-  python: true,
-  mojo: true,
+  cute: "CuTe"
 } as const;

--- a/src/types/misc.ts
+++ b/src/types/misc.ts
@@ -1,6 +1,6 @@
 import { type SandboxStatusType } from "./submission";
 
-export type ProgrammingLanguage = "cuda" | "python" | "mojo";
+export type ProgrammingLanguage = "cuda" | "python" | "mojo" | "cute";
 
 export type DataType = "float16" | "float32" | "int32" | "int16";
 

--- a/src/utils/starter.ts
+++ b/src/utils/starter.ts
@@ -6,6 +6,8 @@ import {
   MOJO_TYPES,
   PYTHON_MISC_TYPES,
   MOJO_MISC_TYPES,
+  CUTE_TYPES,
+  CUTE_MISC_TYPES,
 } from "~/constants/datatypes";
 
 export const generateStarterCode = (
@@ -69,6 +71,27 @@ from memory import UnsafePointer
 # Note: ${names.join(", ")} are all device pointers to ${dataType} arrays
 @export
 fn solution(${paramStr}) raises:
+  `;
+  }
+  if (language == "cute") {
+    const names = parameters
+      .map((parameter: Parameter) =>
+        parameter.pointer === "true" ? parameter.name : null
+      )
+      .filter(Boolean);
+    const paramStr = parameters
+      .map(
+        (parameter: Parameter) =>
+          `${parameter.name}${parameter.pointer === "true" ? `: cute.Tensor` : parameter.type === "[VAR]" ? `: ${CUTE_TYPES[dataType]}` : `: ${CUTE_MISC_TYPES[parameter.type]}`}`
+      )
+      .filter(Boolean)
+      .join(", ");
+    return `import cutlass
+import cutlass.cute as cute
+
+# Note: ${names.join(", ")} are all device tensors
+@cute.jit
+def solution(${paramStr}):
   `;
   }
   return "";


### PR DESCRIPTION
i hope this doesn't break anything

- bump python version to `3.12`
- add CuTe submission support
- move `make_solution_func` into the sample run subprocess (`import cutlass` breaks CUDA context) 
- pin modular version to 25.4, as 25.5 has issues with CDLL and loading in params
- allow T4s with mojo!