### PR TITLE
add anchor to submission result pane

### DIFF
--- a/src/components/problem/SubmissionResults.tsx
+++ b/src/components/problem/SubmissionResults.tsx
@@ -43,7 +43,8 @@ import {
   FaChevronDown,
 } from "react-icons/fa";
 
-import { FiArrowLeft } from "react-icons/fi";
+import { FiArrowLeft, FiExternalLink } from "react-icons/fi";
+import NextLink from "next/link";
 
 import { getStatusIcon } from "~/constants/problem";
 import { useSplitPanel } from "./SplitPanel";
@@ -75,6 +76,7 @@ interface SubmissionResultsProps {
   ) => T extends keyof ResponseTypeMap ? ResponseTypeMap[T] | null : null;
   onBackToProblem: () => void;
   onViewSubmissions: () => void;
+  submissionId?: string | null;
 }
 
 const getStatusMessage = (
@@ -124,6 +126,7 @@ const SubmissionResults = ({
   getTypedResponse,
   onBackToProblem,
   onViewSubmissions,
+  submissionId,
 }: SubmissionResultsProps) => {
   const { splitRatio } = useSplitPanel();
   const useCompactLabels = splitRatio < 40;
@@ -528,6 +531,27 @@ const SubmissionResults = ({
               </>
             );
           })()}
+        </Box>
+      )}
+
+      {submissionId && (
+        <Box pt={2}>
+          <Button
+            as={NextLink}
+            href={`/submissions/${submissionId}`}
+            rightIcon={<Icon as={FiExternalLink} boxSize={4} />}
+            size="sm"
+            variant="ghost"
+            borderRadius="lg"
+            color="gray.300"
+            _hover={{
+              bg: "whiteAlpha.50",
+              color: "white",
+            }}
+            px={4}
+          >
+            View Submission
+          </Button>
         </Box>
       )}
     </VStack>

--- a/src/pages/problems/[slug].tsx
+++ b/src/pages/problems/[slug].tsx
@@ -156,6 +156,7 @@ export default function ProblemPage({ slug }: { slug: string }) {
     getTypedResponse,
     ptxContent: submissionPtxContent,
     sassContent: submissionSassContent,
+    submissionId,
   } = useSubmissionStream(submissionsQuery.refetch);
 
   const [submissionPtxTimestamp, setSubmissionPtxTimestamp] =
@@ -445,6 +446,7 @@ export default function ProblemPage({ slug }: { slug: string }) {
             getTypedResponse={getTypedResponse}
             onBackToProblem={() => setViewType("problem")}
             onViewSubmissions={() => setViewType("submissions")}
+            submissionId={submissionId}
           />
         ) : null;
       default:


### PR DESCRIPTION
ux stuff:
- adds view submission button at the bottom to solidify the link (from the user perspective) between what's happening ephemerally on the page and what's stored in the db 

<img width="557" height="827" alt="image" src="https://github.com/user-attachments/assets/01aae9f5-ed45-49b0-8250-778a246fdf8a" />