### PR TITLE
hotkey fix

### DIFF
--- a/src/hooks/useHotKey.ts
+++ b/src/hooks/useHotKey.ts
@@ -50,7 +50,11 @@ export function useHotkey(
 
       if (metaOk && ctrlOk && altOk && shiftOk) {
         const pressedKey = e.key.toLowerCase();
-        if (["meta", "ctrl", "alt", "shift", "control", "altgraph"].includes(pressedKey)) {
+        if (
+          ["meta", "ctrl", "alt", "shift", "control", "altgraph"].includes(
+            pressedKey
+          )
+        ) {
           return;
         }
         if (pressedKey === key) {


### PR DESCRIPTION
`useHotkey` didn't do parsing right, if you had `combo = "meta+shift+v"` in:

```typescript
const [mod, keyRaw] = combo.toLowerCase().split("+");
const key = keyRaw;
```

the `v` is ignored and it was triggered with just meta + shift 