### PR TITLE
keep extra tensors alive

### DIFF
--- a/engine/runner.py
+++ b/engine/runner.py
@@ -71,11 +71,11 @@ def run_checker(
             actual_output = torch.zeros_like(expected_output, device="cuda").contiguous()
 
             if param_func is None:
-                parameters = utils.make_parameters(
+                parameters, _keep_alive = utils.make_parameters(
                     language, solution_func, input_tensors, actual_output, problem, test_case
                 )
             else:
-                parameters = param_func(
+                parameters, _keep_alive = param_func(
                     language, solution_func, input_tensors, actual_output, problem, test_case
                 )
             solution_func(*parameters)
@@ -177,11 +177,11 @@ def run_sample_case(
         expected_output = problem.reference_solution(*input_tensors).cpu()
         actual_output = torch.zeros_like(expected_output, device="cuda").contiguous()
         if param_func is None:
-            parameters = utils.make_parameters(
+            parameters, _keep_alive = utils.make_parameters(
                 language, solution_func, input_tensors, actual_output, problem, sample
             )
         else:
-            parameters = param_func(
+            parameters, _keep_alive = param_func(
                 language, solution_func, input_tensors, actual_output, problem, sample
             )
 
@@ -256,11 +256,11 @@ def run_sanity_check(
             actual_output = torch.zeros_like(expected_output, device="cuda").contiguous()
 
             if param_func is None:
-                parameters = utils.make_parameters(
+                parameters, _keep_alive = utils.make_parameters(
                     language, solution_func, input_tensors, actual_output, problem, test_case
                 )
             else:
-                parameters = param_func(
+                parameters, _keep_alive = param_func(
                     language, solution_func, input_tensors, actual_output, problem, test_case
                 )
             solution_func(*parameters)

--- a/engine/utils.py
+++ b/engine/utils.py
@@ -619,11 +619,11 @@ def run_dynamic_benchmark(
     """
     # Prepare pointers for CUDA
     if param_func is None:
-        parameters = make_parameters(
+        parameters, _keep_alive = make_parameters(
             language, solution_func, input_tensors, actual_output, problem, test_case
         )
     else:
-        parameters = param_func(
+        parameters, _keep_alive = param_func(
             language, solution_func, input_tensors, actual_output, problem, test_case
         )
 
@@ -857,7 +857,8 @@ def make_parameters(language: str, solution_func, input_tensors, actual_output, 
         extra_params_casted = cast_to_ctype(
             extra_params, solution_func.argtypes[-len(extra_params) :], language
         )
-        return input_ptrs + [output_ptr] + extra_params_casted
+        # Return both the casted params AND the original tensors to keep them alive
+        return input_ptrs + [output_ptr] + extra_params_casted, extra_params
     elif language == "cute":
         from cutlass.cute.runtime import from_dlpack
 
@@ -865,10 +866,10 @@ def make_parameters(language: str, solution_func, input_tensors, actual_output, 
         output_ptr = from_dlpack(actual_output, assumed_align=16)
         extra_params = problem.get_extra_params(test_case)
         extra_params_casted = cast_to_cute(extra_params)
-        return input_ptrs + [output_ptr] + extra_params_casted
+        return input_ptrs + [output_ptr] + extra_params_casted, extra_params
     else:
         extra_params = problem.get_extra_params(test_case)
-        return list(input_tensors) + [actual_output] + list(extra_params)
+        return list(input_tensors) + [actual_output] + list(extra_params), extra_params
 
 
 class SystemOutputCapture:


### PR DESCRIPTION
- for problems like `softmax` that create tensors in `get_extra_params()`, the raw pointers extracted via `data_ptr()` could become invalid if any PyTorch operation (printing, tensor access, etc.) happened between `make_parameters()` and the actual kernel call
- the temp tensors in extra_params had no python references after `make_parameters()` returned, so PyTorch's caching allocator could reclaim their memory
- any subsequent pytorch op could trigger GC, causing the kernel to read garbage/zeros from the now-freed memory
- this was surfaced by #174 when we did work to fill in `actual_output` before calling

fix is to just return `extra_params` alongside the casted pointers so callers keep those tensors alive until after the kernel runs
