### PR TITLE
Mojo 26.1 working

### DIFF
--- a/engine/api.py
+++ b/engine/api.py
@@ -9,7 +9,7 @@ import runner
 DEVEL_IMAGE_NAME = "nvidia/cuda:13.1.0-devel-ubuntu24.04"
 RUNTIME_IMAGE_NAME = "nvidia/cuda:13.1.0-runtime-ubuntu24.04"
 CURR_DIR = Path(__file__).parent
-
+MODULAR_INDEX = "https://modular.gateway.scarf.sh/simple/modular/modular-26.1.0-py3-none-any.whl"
 
 PIP_PACKAGES = ["numpy", "fastapi", "triton", "simplejson", "nvidia-cutlass-dsl", "nvidia-ml-py"]
 UV_PREFIX = "uv pip install --system "
@@ -35,7 +35,7 @@ runtime_image = (
     .env({"PATH": "/root/.local/bin:$PATH"})
     .run_commands("curl -LsSf https://astral.sh/uv/install.sh | sh")
     .run_commands(UV_PREFIX + " ".join(PIP_PACKAGES))
-    .run_commands("uv pip install --system modular==25.4.0")
+    .run_commands(f"uv pip install --system mojo --extra-index-url {MODULAR_INDEX}") 
     # install torch separately with CUDA 12.8
     .run_commands(
         "uv pip install --system torch==2.9.0 --index-url https://download.pytorch.org/whl/cu128"
@@ -52,7 +52,7 @@ def b200_image():
         .env({"PATH": "/root/.local/bin:$PATH"})
         .run_commands("curl -LsSf https://astral.sh/uv/install.sh | sh")
         .run_commands(UV_PREFIX + " ".join(PIP_PACKAGES + ["cuda-tile", "cupy-cuda13x"]))
-        .run_commands("uv pip install --system modular==25.4.0")
+        .run_commands(f"uv pip install --system mojo --extra-index-url {MODULAR_INDEX}") 
         # install torch separately with CUDA 12.8
         .run_commands(
             "uv pip install --system torch==2.9.0 --index-url https://download.pytorch.org/whl/cu128"

--- a/engine/api.py
+++ b/engine/api.py
@@ -35,7 +35,7 @@ runtime_image = (
     .env({"PATH": "/root/.local/bin:$PATH"})
     .run_commands("curl -LsSf https://astral.sh/uv/install.sh | sh")
     .run_commands(UV_PREFIX + " ".join(PIP_PACKAGES))
-    .run_commands(f"uv pip install --system mojo --extra-index-url {MODULAR_INDEX}") 
+    .run_commands(f"uv pip install --system mojo --extra-index-url {MODULAR_INDEX}")
     # install torch separately with CUDA 12.8
     .run_commands(
         "uv pip install --system torch==2.9.0 --index-url https://download.pytorch.org/whl/cu128"
@@ -52,7 +52,7 @@ def b200_image():
         .env({"PATH": "/root/.local/bin:$PATH"})
         .run_commands("curl -LsSf https://astral.sh/uv/install.sh | sh")
         .run_commands(UV_PREFIX + " ".join(PIP_PACKAGES + ["cuda-tile", "cupy-cuda13x"]))
-        .run_commands(f"uv pip install --system mojo --extra-index-url {MODULAR_INDEX}") 
+        .run_commands(f"uv pip install --system mojo --extra-index-url {MODULAR_INDEX}")
         # install torch separately with CUDA 12.8
         .run_commands(
             "uv pip install --system torch==2.9.0 --index-url https://download.pytorch.org/whl/cu128"

--- a/src/constants/datatypes.ts
+++ b/src/constants/datatypes.ts
@@ -41,6 +41,13 @@ export const MOJO_TYPES: Record<DataType, string> = {
   int16: "Int16",
 } as const;
 
+export const MOJO_DTYPE_CONST: Record<DataType, string> = {
+  float32: "DType.float32",
+  float16: "DType.float16",
+  int32: "DType.int32",
+  int16: "DType.int16",
+} as const;
+
 export const MOJO_MISC_TYPES: Record<string, string> = {
   float: "Float32",
   int: "Int32",

--- a/src/utils/starter.ts
+++ b/src/utils/starter.ts
@@ -8,6 +8,8 @@ import {
   MOJO_MISC_TYPES,
   CUTE_TYPES,
   CUTE_MISC_TYPES,
+  DATA_TYPE_DISPLAY_NAMES,
+  MOJO_DTYPE_CONST,
 } from "~/constants/datatypes";
 import { FORBIDDEN_PATTERNS } from "~/constants/forbidden";
 
@@ -76,27 +78,9 @@ def solution(${paramStr}):
     })();
 
     const dtypeConst =
-      dtypeFromPtr?.dtypeConst ??
-      (dataType === "float16"
-        ? "DType.float16"
-        : dataType === "float32"
-          ? "DType.float32"
-          : dataType === "int16"
-            ? "DType.int16"
-            : dataType === "int32"
-              ? "DType.int32"
-              : "DType.float32");
+      dtypeFromPtr?.dtypeConst ?? MOJO_DTYPE_CONST[dataType];
     const dtypeDisplay =
-      dtypeFromPtr?.display ??
-      (dataType === "float16"
-        ? "float16"
-        : dataType === "float32"
-          ? "float32"
-          : dataType === "int16"
-            ? "int16"
-            : dataType === "int32"
-              ? "int32"
-              : "float32");
+      dtypeFromPtr?.display ?? DATA_TYPE_DISPLAY_NAMES[dataType];
 
     // For Mojo, we always pass raw device addresses and cast inside the function.
     // Use Scalar[dtype] so the element type is controlled by `dtype`.
@@ -120,15 +104,13 @@ def solution(${paramStr}):
       .join("\n");
 
     const dtypeBlock = usesDType
-      ? `
-
-comptime dtype = ${dtypeConst}
-`
+      ? `comptime dtype = ${dtypeConst}`
       : "";
 
     return `from gpu import thread_idx, block_idx, block_dim
 from gpu.host import DeviceContext
 from memory import UnsafePointer 
+
 ${dtypeBlock ? dtypeBlock : ""}
 
 # Note: ${names.join(", ")} are device pointers to ${ptrTypeComment}


### PR DESCRIPTION
Mojo Upgrade from v24.1 -> v26.1

New Unsafepointer API works

Support for layouttensor and runtimelayout

Sandbox also works with the new version. 

closes https://github.com/tensara/tensara/issues/158


