### PR TITLE
fix `base_dsl` issue

### DIFF
--- a/engine/runner.py
+++ b/engine/runner.py
@@ -27,7 +27,7 @@ def _cleanup_gpu_memory():
 
 def _cleanup_solution_temp_dir(language: str, solution_func):
     """Clean up temporary directory for script-based solutions."""
-    if language in ("python", "triton", "cute", "cutile"):
+    if language in ("python", "triton", "cutile"):
         try:
             temp_dir = os.path.dirname(solution_func.__code__.co_filename)
             shutil.rmtree(temp_dir)


### PR DESCRIPTION
`solution_func.__code__.co_filename` for CuTe pointed to `/usr/local/lib/python3.13/site-packages/nvidia_cutlass_dsl/python_packages/cutlass/base_dsl/dsl.py`, so the function:
```
def _cleanup_solution_temp_dir(language: str, solution_func):
    """Clean up temporary directory for script-based solutions."""
    if language in ("python",  "cute", "triton", "cutile"):
        try:
            temp_dir = os.path.dirname(solution_func.__code__.co_filename)
            shutil.rmtree(temp_dir)
        except Exception:
            pass
```

just removed the folder entirely lol. this is why it worked on first run, but not on the second (on the same container) 
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tensara/tensara/pull/221" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
