### PR TITLE
Add submission delete option

### DIFF
--- a/src/pages/submissions/[id].tsx
+++ b/src/pages/submissions/[id].tsx
@@ -157,6 +157,28 @@ const SubmissionPage: NextPage<{
     },
   });
 
+  const deleteSubmissionMutation = api.problems.deleteSubmission.useMutation({
+    onSuccess: async () => {
+      toast({
+        title: "Submission deleted",
+        description: "The submission has been removed",
+        status: "success",
+        duration: 3000,
+        isClosable: true,
+      });
+      await router.push("/submissions");
+    },
+    onError: (error) => {
+      toast({
+        title: "Error deleting submission",
+        description: error.message,
+        status: "error",
+        duration: 5000,
+        isClosable: true,
+      });
+    },
+  });
+
   // Check if the current user is the submission owner
   const isOwner = session?.user?.id === submission?.userId;
 
@@ -203,6 +225,23 @@ const SubmissionPage: NextPage<{
         isPublic: !submission.isPublic,
       });
     }
+  };
+
+  const handleDeleteSubmission = () => {
+    if (!submission?.id) {
+      return;
+    }
+
+    const confirmed = window.confirm(
+      "Delete this submission? This cannot be undone."
+    );
+    if (!confirmed) {
+      return;
+    }
+
+    deleteSubmissionMutation.mutate({
+      submissionId: submission.id,
+    });
   };
 
   // Check if the submission has code (is public or user is owner)
@@ -879,6 +918,15 @@ ${code}
                 )}
                 {isOwner && (
                   <HStack spacing={2}>
+                    <Button
+                      size="sm"
+                      colorScheme="red"
+                      variant="outline"
+                      onClick={handleDeleteSubmission}
+                      isLoading={deleteSubmissionMutation.isPending}
+                    >
+                      Delete
+                    </Button>
                     <Text fontSize="sm" color="whiteAlpha.600">
                       Public
                     </Text>

--- a/src/server/api/routers/problems.ts
+++ b/src/server/api/routers/problems.ts
@@ -318,6 +318,46 @@ export const problemsRouter = createTRPCRouter({
       return updatedSubmission;
     }),
 
+  deleteSubmission: protectedProcedure
+    .input(z.object({ submissionId: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      const submission = await ctx.db.submission.findUnique({
+        where: { id: input.submissionId },
+        select: {
+          userId: true,
+          problem: {
+            select: {
+              slug: true,
+              title: true,
+            },
+          },
+        },
+      });
+
+      if (!submission) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Submission not found",
+        });
+      }
+
+      if (submission.userId !== ctx.session.user.id) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "You can only delete your own submissions",
+        });
+      }
+
+      await ctx.db.submission.delete({
+        where: { id: input.submissionId },
+      });
+
+      return {
+        id: input.submissionId,
+        problem: submission.problem,
+      };
+    }),
+
   getBaselineBenchmarks: publicProcedure
     .input(z.object({ slug: z.string() }))
     .query(async ({ ctx, input }) => {


### PR DESCRIPTION
## Summary
- add an owner-only `deleteSubmission` protected mutation
- add a Delete button on the submission detail page with a confirmation prompt
- redirect back to `/submissions` after a successful delete

## Testing
- `pnpm exec tsc --noEmit --pretty false`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tensara/tensara/pull/228" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
