### PR TITLE
[benchmarking] suggestions for improving benchmark accuracy

### DIFF
--- a/engine/utils.py
+++ b/engine/utils.py
@@ -1061,6 +1061,11 @@ def run_dynamic_benchmark(
             gpu_monitor.current_run_key = run_key
             gpu_monitor.take_sample_now(run_key)
 
+        buffer = torch.empty(256e8 // 4, dtype=torch.int, device="cuda")
+        for _ in range(5):
+            buffer.zero_()
+        del buffer
+
         # Start timing
         start_event.record()
 
@@ -1122,19 +1127,22 @@ def run_dynamic_benchmark(
         gpu_monitor.stop()
 
     # Calculate averages
-    mean_runtime = statistics.mean(runtimes) if runtimes else 0
+    # mean_runtime = statistics.mean(runtimes) if runtimes else 0
+
+    # Use min sample for more accurate performance comparisons
+    min_runtime = min(runtimes) if runtimes else 0
 
     benchmark_result = {
         "name": test_case["name"],
         "test_id": test_id,
-        "runtime_ms": mean_runtime * 1000,
+        "runtime_ms": min_runtime * 1000,
     }
 
     if gpu_monitor:
         benchmark_result["runs"] = runs
 
-    if has_flops and flops is not None and mean_runtime > 0:
-        benchmark_result["gflops"] = (flops / mean_runtime) / 1e9
+    if has_flops and flops is not None and min_runtime > 0:
+        benchmark_result["gflops"] = (flops / min_runtime) / 1e9
 
     return benchmark_result
 


### PR DESCRIPTION
Adds a brief memory flush (256MB * 5 times) before sample collection; in PyTorch land we have found that this greatly reduces the prevalence of launch overhead in our collected samples. The memory flush acts to pre-fill the GPU with a moment of work, such that the start, kernel, and end events are not immediately executed but rather queued; otherwise, the duration between the start and end events includes not only the kernel's runtime but also the CPU duration of the C -> Python transition while the start event's record call is returning, the Python -> C -> Python transition of launching the kernel, and the Python -> C transition of recording the end event.

Switches runtime calculation to minimum rather than median. Minimum is usually more accurate when the # of samples you can collect is limited (such as in this case, where I guess you wouldn't want to spend much compute on each individual submissions), median is preferred if you have many samples. Since this benchmarking setup seems to collect only a handful of samples, minimum would likely lead to more stable results.